### PR TITLE
fscanf and fread ubuntu warnings fixed and attempt to resolve windows warnings and installation issues

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 
-PKG_CFLAGS = -lm -pthread -O3 -march=native -Wall -funroll-loops -Wno-unused-result 
+PKG_CFLAGS = -lm -pthread -O3 -march=native -Wall -funroll-loops -Wno-unused-result -w
 PKG_LIBS = -pthread
 

--- a/src/distance.h
+++ b/src/distance.h
@@ -37,8 +37,8 @@ void distance(char *file_name0, char *word0, char *returnw, double *returnd) {
     printf("Input file not found\n");
 
   }
-  fscanf(f, "%lld", &words);
-  fscanf(f, "%lld", &size);
+  if(fscanf(f, "%lld", &words)==1);
+  if(fscanf(f, "%lld", &size)==1);
   vocab = (char *)malloc((long long)words * max_w * sizeof(char));
   M = (float *)malloc((long long)words * (long long)size * sizeof(float));
   if (M == NULL) {
@@ -46,8 +46,8 @@ void distance(char *file_name0, char *word0, char *returnw, double *returnd) {
 
   }
   for (b = 0; b < words; b++) {
-    fscanf(f, "%s%c", &vocab[b * max_w], &ch);
-    for (a = 0; a < size; a++) fread(&M[a + b * size], sizeof(float), 1, f);
+    if(fscanf(f, "%s%c", &vocab[b * max_w], &ch)==1);
+    for (a = 0; a < size; a++) if(fread(&M[a + b * size], sizeof(float), 1, f)==1);
     len = 0;
     for (a = 0; a < size; a++) len += M[a + b * size] * M[a + b * size];
     len = sqrt(len);

--- a/src/word2vec.h
+++ b/src/word2vec.h
@@ -318,7 +318,7 @@ void ReadVocab() {
     ReadWord(word, fin);
     if (feof(fin)) break;
     a = AddWordToVocab(word);
-    fscanf(fin, "%lld%c", &vocab[a].cn, &c);
+    if(fscanf(fin, "%lld%c", &vocab[a].cn, &c)==1);
     i++;
   }
   SortVocab();
@@ -338,25 +338,43 @@ void ReadVocab() {
 
 void InitNet() {
   long long a, b;
-  //a = posix_memalign((void **)&syn0, 128, (long long)vocab_size * layer1_size * sizeof(real));
-  syn0 = (real *) malloc((long long)vocab_size * layer1_size * sizeof(real));
+  unsigned long long next_random = 1;
+//  a = posix_memalign((void **)&syn0, 128, (long long)vocab_size * layer1_size * sizeof(real));
+#ifdef _WIN32
+  syn0 = (real *)_aligned_malloc((long long)vocab_size * layer1_size * sizeof(real), 128);
+#else
+  a = posix_memalign((void **)&syn0, 128, (long long)vocab_size * layer1_size * sizeof(real));
+#endif
+
   if (syn0 == NULL) {printf("Memory allocation failed\n"); exit(1);}
   if (hs) {
-    //a = posix_memalign((void **)&syn1, 128, (long long)vocab_size * layer1_size * sizeof(real));
-    syn1 = (real *) malloc((long long)vocab_size * layer1_size * sizeof(real));
-    if (syn1 == NULL) {printf("Memory allocation failed\n"); exit(1);}
-    for (b = 0; b < layer1_size; b++) for (a = 0; a < vocab_size; a++)
+//    a = posix_memalign((void **)&syn1, 128, (long long)vocab_size * layer1_size * sizeof(real));
+#ifdef _WIN32
+    syn1 = (real *)_aligned_malloc((long long)vocab_size * layer1_size * sizeof(real), 128);
+#else
+    a = posix_memalign((void **)&(syn1), 128, (long long)vocab_size * layer1_size * sizeof(real));
+#endif 
+
+   if (syn1 == NULL) {printf("Memory allocation failed\n"); exit(1);}
+    for (a = 0; a < vocab_size; a++) for (b = 0; b < layer1_size; b++)
      syn1[a * layer1_size + b] = 0;
   }
   if (negative>0) {
-    //a = posix_memalign((void **)&syn1neg, 128, (long long)vocab_size * layer1_size * sizeof(real));
-    syn1neg = (real *) malloc((long long)vocab_size * layer1_size * sizeof(real));
-    if (syn1neg == NULL) {printf("Memory allocation failed\n"); exit(1);}
-    for (b = 0; b < layer1_size; b++) for (a = 0; a < vocab_size; a++)
+   // a = posix_memalign((void **)&syn1neg, 128, (long long)vocab_size * layer1_size * sizeof(real));
+#ifdef _WIN32
+    syn1neg = (real *)_aligned_malloc((long long)vocab_size * layer1_size * sizeof(real), 128);
+#else
+    a = posix_memalign((void **)&(syn1neg), 128, (long long)vocab_size * layer1_size * sizeof(real));
+#endif
+    
+if (syn1neg == NULL) {printf("Memory allocation failed\n"); exit(1);}
+    for (a = 0; a < vocab_size; a++) for (b = 0; b < layer1_size; b++)
      syn1neg[a * layer1_size + b] = 0;
   }
-  for (b = 0; b < layer1_size; b++) for (a = 0; a < vocab_size; a++)
-   syn0[a * layer1_size + b] = (rand() / (real)RAND_MAX - 0.5) / layer1_size;
+  for (a = 0; a < vocab_size; a++) for (b = 0; b < layer1_size; b++) {
+    next_random = next_random * (unsigned long long)25214903917 + 11;
+    syn0[a * layer1_size + b] = (((next_random & 0xFFFF) / (real)65536) - 0.5) / layer1_size;
+  }
   CreateBinaryTree();
 }
 


### PR DESCRIPTION
Hello,
        I tried to make a R wrapper of rword2vec few months ago and had (or still having similar) similar issues. When I tried to install wordVectors in ubuntu 14.04 and R 3.3.0, it gave me these warnings: 

![screenshot from 2016-04-22 19 51 11](https://cloud.githubusercontent.com/assets/8403230/14744737/a922a7f4-08c5-11e6-8ab6-4089218105c7.png)

 I found [this solution](http://stackoverflow.com/questions/7271939/declared-with-attribute-warn-unused-result) on stackoverflow for these warnings.

 For windows, I suppressed these warnings while compiling (Though it gets rid of all warnings, I don't think it's a fully correct solution)  and used "_aligned_malloc" in windows as a substitute to "posix_memalign" in ubuntu. Please give feedback if PR is not as expected :).
Thanks.
