### PR TITLE
Does this 

### DIFF
--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 
-PKG_CFLAGS = -lm -pthread -O3 -march=native -Wall -funroll-loops -Wno-unused-result -w
+PKG_CFLAGS = -lm -pthread -O3 -march=native -CFLAGS=-mno-avx -Wall -funroll-loops -Wno-unused-result -w
 PKG_LIBS = -pthread
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 
-PKG_CFLAGS = -lm -pthread -O3 -march=native CFLAGS="-mno-avx" -Wall -funroll-loops -Wno-unused-result -w
+PKG_CFLAGS = -lm -pthread -O3 -march=native -mno-avx -Wall -funroll-loops -Wno-unused-result -w
 PKG_LIBS = -pthread
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,4 +1,4 @@
 
-PKG_CFLAGS = -lm -pthread -O3 -march=native -CFLAGS=-mno-avx -Wall -funroll-loops -Wno-unused-result -w
+PKG_CFLAGS = -lm -pthread -O3 -march=native CFLAGS="-mno-avx" -Wall -funroll-loops -Wno-unused-result -w
 PKG_LIBS = -pthread
 


### PR DESCRIPTION
I noticed a [Stack Overflow user](http://stackoverflow.com/questions/37445507/install-githubbmschmidt-wordvectors) saying that this fork by fixes the [Windows 8 installation bug](https://github.com/bmschmidt/wordVectors/issues/2). I was hoping @cpeeples might see this tag and be able to explain what the changes to Makevars.win are doing. Do they fix the versions of Windows that don't work? Is there any reason to think they might break the versions of Windows that are already working? Unfortunately I can't test on Windows myself.
