### PR TITLE
Dont fail completely on no prep text.

### DIFF
--- a/R/word2vec.R
+++ b/R/word2vec.R
@@ -142,9 +142,13 @@ prep_word2vec <- function(origin,destination,lowercase=F,
       tokenize_words(lowercase) %>%
       stringr::str_c(collapse = " ")
 
-    stopifnot(length(text) == 1)
-    readr::write_lines(text, file_out, append = TRUE)
-    return(TRUE)
+    if (length(text) == 1) {
+      readr::write_lines(text, file_out, append = TRUE)
+      return(TRUE)
+    } else {
+      message("Warning: No text to prep in ", file_in)
+      return(FALSE)
+    }
   }
 
 


### PR DESCRIPTION
If a file has no text after tokenizing, don't fail catastrophically. Print out a warning instead.

Previously:
```
Prepping temp//106.txt
Error: length(text) == 1 is not TRUE
>
```

Now:
```
Prepping temp//106.txt
Warning: No text to prep in temp//106.txt
Prepping temp//107.txt
...
```

This was failing on a file I was trying to run on that only contained emojis. These were removed by `skip_word_none = TRUE` in `stri_split_boundaries`. Rather than change that code, I figure a warning would be a better solution. 